### PR TITLE
Correctly calculate negative temperatures

### DIFF
--- a/src/ClosedCube_BME680.cpp
+++ b/src/ClosedCube_BME680.cpp
@@ -207,14 +207,15 @@ double ClosedCube_BME680::readTemperature() {
 
 	uint32_t temp_raw = ((uint32_t)temp_msb << 12) | ((uint32_t)temp_lsb << 4) | ((uint32_t)temp_xlsb >> 4);
 
-	uint32_t var1, var2, var3, calc_temp;
+	int64_t var1, var2, var3;
+	int16_t calc_temp;
 
 	var1 = ((int32_t)temp_raw / 8) - ((int32_t)_calib_temp.t1 * 2);
 	var2 = (var1 * (int32_t)_calib_temp.t2) / 2048;
 	var3 = ((var1 / 2) * (var1 / 2)) / 4096;
 	var3 = ((var3) * ((int32_t)_calib_temp.t3 * 16)) / 16384;
 	_calib_dev.tfine = (int32_t)(var2 + var3);
-	calc_temp =(int16_t)(((_calib_dev.tfine * 5) + 128) / 256);
+	calc_temp = (int16_t)(((_calib_dev.tfine * 5) + 128) / 256);
 
 	return calc_temp / 100.0;
 }


### PR DESCRIPTION
Found another minor issue, hope that's ok :)

When using uint32_t for var{1,2,3}, negative temperature values cause a
underflow resulting in completely wrong values:
```
result: Raw temp: 430552
T=3.23C, RH=33.00%, P=984.23hPa, G=764616 Ohms
status: (1,1,0,0) (newDataFlag,StatusFlag,GasFlag,GasIndex)

result: Raw temp: 424323
T=1.27C, RH=34.00%, P=989.80hPa, G=24984 Ohms
status: (1,1,0,0) (newDataFlag,StatusFlag,GasFlag,GasIndex)

result: Raw temp: 418736
T=42949428.00C, RH=100.00%, P=1004.44hPa, G=38953 Ohms
status: (1,1,0,0) (newDataFlag,StatusFlag,GasFlag,GasIndex)

result: Raw temp: 413843
T=42949424.00C, RH=100.00%, P=974.18hPa, G=62376 Ohms
status: (1,1,0,0) (newDataFlag,StatusFlag,GasFlag,GasIndex)
```

Using int64_t like the Bosch reference driver remedies this issue.
Although int32_t would work too for negative values, it might lead to
issues for high positive temperatures.