### PR TITLE
Update ClosedCube_BME680.cpp

### DIFF
--- a/src/ClosedCube_BME680.cpp
+++ b/src/ClosedCube_BME680.cpp
@@ -29,9 +29,9 @@ THE SOFTWARE.
 */
 
 
-#include <Wire.h>
-#include "ClosedCube_BME680.h"
 
+#include "ClosedCube_BME680.h"
+#include <Wire.h>
 
 
 ClosedCube_BME680::ClosedCube_BME680() {


### PR DESCRIPTION
Previous #include order could leads to compilation error, depending on the platform (in my case, stm32l0 arduinoCore : https://github.com/GrumpyOldPizza/ArduinoCore-stm32l0)